### PR TITLE
Simple Role Management added.

### DIFF
--- a/src/PetApplication/Controllers/PetTypesController.cs
+++ b/src/PetApplication/Controllers/PetTypesController.cs
@@ -38,6 +38,7 @@ namespace PetApplication.Controllers
         }
 
         // GET: PetTypes/Create
+        [Authorize(Roles = "Admin")]
         public ActionResult Create()
         {
             ViewBag.Current = "PetTypes";
@@ -49,6 +50,7 @@ namespace PetApplication.Controllers
         // more details see https://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Admin")]
         public ActionResult Create([Bind(Include = "PetTypeID,PetTypeName")] PetType petType)
         {
             if (ModelState.IsValid)
@@ -62,6 +64,7 @@ namespace PetApplication.Controllers
         }
 
         // GET: PetTypes/Edit/5
+        [Authorize(Roles = "Admin")]
         public ActionResult Edit(int? id)
         {
             ViewBag.Current = "PetTypes";
@@ -82,6 +85,7 @@ namespace PetApplication.Controllers
         // more details see https://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Admin")]
         public ActionResult Edit([Bind(Include = "PetTypeID,PetTypeName")] PetType petType)
         {
             if (ModelState.IsValid)
@@ -94,6 +98,7 @@ namespace PetApplication.Controllers
         }
 
         // GET: PetTypes/Delete/5
+        [Authorize(Roles = "Admin")]
         public ActionResult Delete(int? id)
         {
             ViewBag.Current = "PetTypes";
@@ -112,6 +117,7 @@ namespace PetApplication.Controllers
         // POST: PetTypes/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = "Admin")]
         public ActionResult DeleteConfirmed(int id)
         {
             ViewBag.Current = "PetTypes";

--- a/src/PetApplication/Migrations/Configuration.cs
+++ b/src/PetApplication/Migrations/Configuration.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNet.Identity.EntityFramework;
+
 namespace PetApplication.Migrations
 {
     using System;
@@ -26,6 +28,8 @@ namespace PetApplication.Migrations
             //      new Person { FullName = "Rowan Miller" }
             //    );
             //
+
+            context.Roles.AddOrUpdate(new IdentityRole("Admin"));
         }
     }
 }


### PR DESCRIPTION
Role management added. Role is in Migration/Configuration.cs. So a `update-database` command is needed. Role is applied in **Create, Edit & Delete** actions in **PetType** controller. Users who is in the role of "Admin" will be able to access this, others won't.  Though role management UI is not implemented,  UserRoles have to be set in database by hand. 

- Role Table : _**AspNetRoles**_
- User Table : _**userInfo**_
- User Role Table : _**AspNetUserRoles**_